### PR TITLE
Fixes for Magic Flush and Forbidden Monarch + small QoL

### DIFF
--- a/scripts/card-controller.js
+++ b/scripts/card-controller.js
@@ -789,7 +789,10 @@ static async createSetActivationMessage(setData, playerId, mpCost) {
     damageTypeLabel: damageData?.type ? game.i18n.localize(`FU.Damage${window.capitalize(damageData.type)}`) || damageData.type.toUpperCase() : '',
     highRoll: damageData?.highRoll || 0,
     baseDamage: damageData?.baseDamage || 0,
-    
+
+    // Damage label
+    damageTypeIcon: damageData?.type !== 'air' ? damageData?.type : 'wind', // Special case: air damage uses fu-wind icon class
+
     // Healing data
     isHealingSet: isHealingSet,
     healingData: healingData,

--- a/scripts/card-controller.js
+++ b/scripts/card-controller.js
@@ -287,7 +287,7 @@ static async playSetToTable(setData, indicator) {
     return isJoker && (!card.getFlag(MODULE_ID, 'phantomSuit') || !card.getFlag(MODULE_ID, 'phantomValue'));
   });
   
-  if (hasUnassignedJoker) {
+  if (hasUnassignedJoker && setData.type !== 'forbidden-monarch') {
     return false;
   }
   
@@ -349,7 +349,7 @@ static async playSetToTable(setData, indicator) {
       word.charAt(0).toUpperCase() + word.slice(1)
     ).join(' ');
 
-        // Verify handlers are still attached
+    // Verify handlers are still attached
     if (window.FuAceCards?.EventHandlers) {
       window.FuAceCards.EventHandlers.verifyHandDrawerHandlers();
     } else if (typeof EventHandlers !== 'undefined') {

--- a/scripts/card-controller.js
+++ b/scripts/card-controller.js
@@ -21,6 +21,12 @@ static async drawCard() {
     return false;
   }
 
+  // Player can't have more than 5 cards in hand
+  if ((piles.hand.cards).size >= 5) {
+    ui.notifications.info(`${MODULE_ID} | Cannot draw: Player has maximum cards in hand (5)`);
+    return
+  }
+
   // Let's first check how many AVAILABLE cards we have (with drawn=false)
   const availableCards = Array.from(piles.deck.cards).filter(c => !c.drawn);
   console.log(`${MODULE_ID} | Deck has ${piles.deck.cards.size} total cards, ${availableCards.length} available for drawing`);

--- a/scripts/damage-integration.js
+++ b/scripts/damage-integration.js
@@ -372,6 +372,7 @@ export class DamageIntegration {
                 // Damage: 25 + total value of cards, type matches the suit
                 const firstCard = setData.cards[0];
                 const suit = DamageIntegration.getCardSuit(firstCard);
+                console.log(`${MODULE_ID} | First card damage type: ${suitToDamageType[suit.toLowerCase()]}`);
                 const damageType = suitToDamageType[suit.toLowerCase()] || 'physical';
                 
                 return {
@@ -428,7 +429,7 @@ export class DamageIntegration {
     // Get card suit from card data
     static getCardSuit(card) {
         // Try to get suit from card data, flags, or name
-        return card.suit || card.getFlag('fu-ace-cards', 'suit') || 
+        return card.getFlag('fu-ace-cards', 'phantomSuit') || card.suit || card.getFlag('fu-ace-cards', 'suit') || 
                card.name.toLowerCase().match(/(clubs?|diamonds?|hearts?|spades?)/)?.[0] || '';
     }
 }

--- a/scripts/set-detector.js
+++ b/scripts/set-detector.js
@@ -89,6 +89,11 @@ export function detectFabulaUltimaSets(cards) {
   
   // Sort by value for easier analysis
   validCards.sort((a, b) => a.value - b.value);
+
+  // Forbidden Monarch: 4 cards of same value (no jokers) + 1 joker
+  // Special case: Need to use both nonJokers and jokers separately
+  const forbiddenMonarch = findForbiddenMonarch(nonJokers, jokers);
+  if (forbiddenMonarch) sets.push(forbiddenMonarch);
   
   // Jackpot: Must be 4 cards of same value, none of which is a joker
   const jackpot = findJackpot(nonJokers);  // Explicitly use non-jokers
@@ -123,11 +128,6 @@ export function detectFabulaUltimaSets(cards) {
   // Can include jokers with their phantom values
   const magicPairs = findMagicPair(validCards);
   sets.push(...magicPairs);
-  
-  // Forbidden Monarch: 4 cards of same value (no jokers) + 1 joker
-  // Special case: Need to use both nonJokers and jokers separately
-  const forbiddenMonarch = findForbiddenMonarch(nonJokers, jokers);
-  if (forbiddenMonarch) sets.push(forbiddenMonarch);
   
   // Post-processing: For sets with jokers, mark them in the set data
   for (const set of sets) {

--- a/scripts/set-detector.js
+++ b/scripts/set-detector.js
@@ -372,7 +372,7 @@ function groupByValue(cards) {
 
 function groupBySuit(cards) {
   return cards.reduce((groups, card) => {
-    if (card.isJoker) return groups; // Skip jokers
+    if (!card.suit && !card.value) return groups; // Skip unassigned jokers
     const suit = card.suit;
     if (!groups[suit]) groups[suit] = [];
     groups[suit].push(card);

--- a/scripts/ui-manager.js
+++ b/scripts/ui-manager.js
@@ -296,7 +296,7 @@ export class UIManager {
     }
     
     // Update set info bar for hand with click handler
-    if (hand.cards.size > 0) {
+    if (hand.cards.size >= 0) {
       // Check if window.FuAceCards exists and has handleHandSetClick method
       const handleSetClick = window.FuAceCards?.handleHandSetClick || 
                           ((indicator) => console.warn(`${MODULE_ID} | handleHandSetClick not found`));

--- a/templates/set-activation.hbs
+++ b/templates/set-activation.hbs
@@ -70,7 +70,7 @@
           <div class="startcap"></div>
           <div>{{damageValue}}</div>
           <div class="endcap" data-tooltip="{{damageTypeLabel}}">
-            <i class="fua fu-{{damageType}}"></i>
+            <i class="fua fu-{{damageTypeIcon}}"></i>
           </div>
         </label>
       </a>


### PR DESCRIPTION
This PR is intended to implement the following:

- Magic flush using cards and jokers is correctly identified as a valid set
- Magic flush's damage type is assigned even if joker is in the the set's first position
- Magic flush's air damage correctly shows the fu-wind icon
- Forbidden Monarch (4 cards same value + joker) can be played even if the joker doesn't have an assigned value
- Playing the Forbidden Monarch to the table corretly updates the set info bar
- Blocked buying cards if player already have 5 cards in hand